### PR TITLE
fix: fail-close heartbeat observation ticks

### DIFF
--- a/Projects/continuous/Qor/victor/src/heartbeat/mod.ts
+++ b/Projects/continuous/Qor/victor/src/heartbeat/mod.ts
@@ -62,7 +62,9 @@ export interface HeartbeatResult {
   tasks?: Task[];
   provenanceHash?: string;
   error?: string;
-  executionStatus?: "completed" | "blocked" | "failed" | "quarantined";
+  executionStatus?: "completed" | "blocked" | "failed" | "quarantined" | "no-op";
+  heartbeatStatus?: "completed" | "blocked" | "failed" | "quarantined" | "no-op";
+  heartbeatRecordPath?: string;
 }
 
 export async function heartbeat(ctx: RuntimeAgentContext): Promise<HeartbeatResult> {

--- a/Projects/continuous/Qor/victor/src/heartbeat/runtime.ts
+++ b/Projects/continuous/Qor/victor/src/heartbeat/runtime.ts
@@ -1,6 +1,7 @@
 import {
   applyHeartbeatOutcome,
   loadHeartbeatState,
+  saveHeartbeatRecord,
   saveHeartbeatState,
   type HeartbeatPersistentState,
 } from "./state-persistence";
@@ -23,15 +24,24 @@ import {
   forgeTaskToTask,
   handleEmptyQueue,
 } from "./mod";
+import type {
+  HeartbeatBranch,
+  HeartbeatEvidenceRef,
+  HeartbeatRecord,
+  HeartbeatRecordStatus,
+} from "./types";
 
 const DEFAULT_HEARTBEAT_STATE_PATH =
   "/home/workspace/Projects/continuous/Qor/.qore/projects/victor-resident/heartbeat-state.json";
+const DEFAULT_HEARTBEAT_RECORDS_DIR =
+  "/home/workspace/Projects/continuous/Qor/.qore/projects/victor-resident/heartbeat-records";
 const DEFAULT_FORGE_SECRET_PATH =
   "/home/workspace/Projects/continuous/Qor/forge/.secrets/api_key";
 const DEFAULT_FORGE_API_BASE = "http://localhost:3099";
 
 export interface RuntimeAgentContext extends AgentContext {
   heartbeatStatePath?: string;
+  heartbeatRecordsDir?: string;
   writeBackConfig?: WriteBackConfig;
   forgeApiKeyPath?: string;
 }
@@ -64,7 +74,7 @@ function buildExecutedResult(
 
 function persistOutcome(
   path: string,
-  outcome: HeartbeatPersistentState["lastTickStatus"],
+  outcome: HeartbeatRecordStatus,
   taskId?: string | null,
 ): HeartbeatPersistentState {
   const now = new Date().toISOString();
@@ -74,30 +84,137 @@ function persistOutcome(
   return next;
 }
 
+function createTickId(): string {
+  return `tick-${Date.now()}`;
+}
+
+function buildRecordPath(recordsDir: string, tickId: string): string {
+  return `${recordsDir}/${tickId}.json`;
+}
+
+function persistRecord(
+  recordsDir: string,
+  record: HeartbeatRecord,
+): string {
+  const recordPath = buildRecordPath(recordsDir, record.tickId);
+  const sealedRecord: HeartbeatRecord = {
+    ...record,
+    branchHistory: record.branchHistory.includes("persisted")
+      ? record.branchHistory
+      : [...record.branchHistory, "persisted"],
+  };
+  saveHeartbeatRecord(recordPath, sealedRecord);
+  return recordPath;
+}
+
+function finalizeTick(
+  statePath: string,
+  recordsDir: string,
+  result: HeartbeatResult,
+  status: HeartbeatRecordStatus,
+  startedAt: string,
+  branchHistory: HeartbeatBranch[],
+  summary: string,
+  evidence: HeartbeatEvidenceRef[],
+  taskId?: string | null,
+): HeartbeatResult {
+  const tickId = createTickId();
+  const recordPath = persistRecord(recordsDir, {
+    tickId,
+    sessionId: tickId,
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    status,
+    branchHistory,
+    claimedTaskId: taskId ?? null,
+    summary,
+    evidence,
+  });
+  persistOutcome(statePath, status, taskId);
+  return {
+    ...result,
+    executionStatus: result.executionStatus ?? status,
+    heartbeatStatus: status,
+    heartbeatRecordPath: recordPath,
+  };
+}
+
 export async function runHeartbeatTick(
   ctx: RuntimeAgentContext,
 ): Promise<HeartbeatResult> {
   const queue = readForgeQueue(ctx.forgeQueuePath ?? DEFAULT_FORGE_QUEUE_PATH);
   const statePath = ctx.heartbeatStatePath ?? DEFAULT_HEARTBEAT_STATE_PATH;
+  const recordsDir = ctx.heartbeatRecordsDir ?? DEFAULT_HEARTBEAT_RECORDS_DIR;
+  const startedAt = new Date().toISOString();
 
   if (!queue.task) {
     const fallback = await handleEmptyQueue(ctx);
-    const status = fallback.status === "QUARANTINE" ? "quarantined" : null;
-    if (status) persistOutcome(statePath, status);
-    return fallback;
+    if (fallback.status === "QUARANTINE") {
+      return finalizeTick(
+        statePath,
+        recordsDir,
+        fallback,
+        "quarantined",
+        startedAt,
+        ["observed", "quarantined"],
+        fallback.error ?? "Heartbeat quarantined after empty-queue derivation failure.",
+        [{ kind: "project-scan", target: "forge-queue", status: "failure", artifact: null }],
+      );
+    }
+
+    if (fallback.status === "USER_PROMPT") {
+      return finalizeTick(
+        statePath,
+        recordsDir,
+        fallback,
+        "blocked",
+        startedAt,
+        ["observed", "blocked"],
+        "Heartbeat blocked: no eligible work and autonomy level requires user input.",
+        [{ kind: "project-scan", target: "forge-queue", status: "success", artifact: null }],
+      );
+    }
+
+    return finalizeTick(
+      statePath,
+      recordsDir,
+      fallback,
+      "no-op",
+      startedAt,
+      ["observed"],
+      "Heartbeat observed state and derived follow-up work, but no governed claim or remediation occurred.",
+      [{ kind: "project-scan", target: "forge-queue", status: "success", artifact: null }],
+    );
   }
 
   const writeBack = resolveWriteBackConfig(ctx);
   if (!writeBack) {
-    persistOutcome(statePath, "quarantined");
-    return { status: "QUARANTINE", error: "missing_writeback_config" };
+    return finalizeTick(
+      statePath,
+      recordsDir,
+      { status: "QUARANTINE", error: "missing_writeback_config" },
+      "quarantined",
+      startedAt,
+      ["observed", "quarantined"],
+      "Heartbeat quarantined: missing Forge write-back configuration.",
+      [{ kind: "task-writeback", target: "writeback-config", status: "missing", artifact: null }],
+    );
   }
 
   const task = forgeTaskToTask(queue.task);
   const claimed = await claimTask(writeBack, queue.task.taskId);
   if (!claimed) {
-    persistOutcome(statePath, "quarantined", queue.task.taskId);
-    return { status: "QUARANTINE", error: "claim_failed", tasks: [task] };
+    return finalizeTick(
+      statePath,
+      recordsDir,
+      { status: "QUARANTINE", error: "claim_failed", tasks: [task] },
+      "quarantined",
+      startedAt,
+      ["observed", "claimed", "quarantined"],
+      `Heartbeat quarantined: failed to claim task ${queue.task.taskId}.`,
+      [{ kind: "task-writeback", target: queue.task.taskId, status: "failure", artifact: null }],
+      queue.task.taskId,
+    );
   }
 
   const claimedState = loadHeartbeatState(statePath);
@@ -111,8 +228,22 @@ export async function runHeartbeatTick(
       acceptanceMet: result.acceptanceMet,
     });
     const receipt = await completeTask(writeBack, queue.task.taskId, queue.task.phaseId, evidence);
-    persistOutcome(statePath, "completed", queue.task.taskId);
-    return buildExecutedResult(task, result.status, receipt);
+    return finalizeTick(
+      statePath,
+      recordsDir,
+      buildExecutedResult(task, result.status, receipt),
+      "completed",
+      startedAt,
+      ["observed", "claimed", "executed"],
+      result.summary,
+      [{
+        kind: "task-writeback",
+        target: queue.task.taskId,
+        status: receipt ? "success" : "missing",
+        artifact: receipt?.provenanceHash ?? null,
+      }],
+      queue.task.taskId,
+    );
   }
 
   if (result.status === "blocked") {
@@ -122,15 +253,38 @@ export async function runHeartbeatTick(
       queue.task.phaseId,
       result.reason ?? result.summary,
     );
-    persistOutcome(statePath, "blocked", queue.task.taskId);
-    return buildExecutedResult(task, result.status, receipt);
+    return finalizeTick(
+      statePath,
+      recordsDir,
+      buildExecutedResult(task, result.status, receipt),
+      "blocked",
+      startedAt,
+      ["observed", "claimed", "blocked"],
+      result.summary,
+      [{
+        kind: "task-writeback",
+        target: queue.task.taskId,
+        status: receipt ? "success" : "missing",
+        artifact: receipt?.provenanceHash ?? null,
+      }],
+      queue.task.taskId,
+    );
   }
 
-  persistOutcome(statePath, result.status === "failed" ? "failed" : "quarantined", queue.task.taskId);
-  return {
-    status: "QUARANTINE",
-    error: result.reason ?? result.summary,
-    tasks: [task],
-    executionStatus: result.status,
-  };
+  return finalizeTick(
+    statePath,
+    recordsDir,
+    {
+      status: "QUARANTINE",
+      error: result.reason ?? result.summary,
+      tasks: [task],
+      executionStatus: result.status,
+    },
+    result.status === "failed" ? "failed" : "quarantined",
+    startedAt,
+    ["observed", "claimed", result.status === "failed" ? "failed" : "quarantined"],
+    result.summary,
+    [{ kind: "task-writeback", target: queue.task.taskId, status: "failure", artifact: null }],
+    queue.task.taskId,
+  );
 }

--- a/Projects/continuous/Qor/victor/src/heartbeat/state-persistence.ts
+++ b/Projects/continuous/Qor/victor/src/heartbeat/state-persistence.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
 import { dirname } from "path";
+import type { HeartbeatRecord, HeartbeatRecordStatus } from "./types";
 
 export interface HeartbeatPersistentState {
   consecutiveSuccesses: number;
@@ -7,7 +8,7 @@ export interface HeartbeatPersistentState {
   consecutiveBlocked: number;
   totalTicks: number;
   lastTickTimestamp: string | null;
-  lastTickStatus: "completed" | "blocked" | "failed" | "quarantined" | null;
+  lastTickStatus: HeartbeatRecordStatus | null;
   lastClaimedTaskId: string | null;
   lastCompletedTaskId: string | null;
 }
@@ -44,9 +45,23 @@ export function saveHeartbeatState(
   writeFileSync(path, JSON.stringify(state, null, 2));
 }
 
+export function loadHeartbeatRecord(path: string): HeartbeatRecord | null {
+  try {
+    if (!existsSync(path)) return null;
+    return JSON.parse(readFileSync(path, "utf-8")) as HeartbeatRecord;
+  } catch {
+    return null;
+  }
+}
+
+export function saveHeartbeatRecord(path: string, record: HeartbeatRecord): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(record, null, 2));
+}
+
 export function applyHeartbeatOutcome(
   state: HeartbeatPersistentState,
-  outcome: HeartbeatPersistentState["lastTickStatus"],
+  outcome: HeartbeatRecordStatus,
   tickTimestamp: string,
   taskId?: string | null,
 ): HeartbeatPersistentState {
@@ -66,10 +81,18 @@ export function applyHeartbeatOutcome(
   }
 
   next.consecutiveSuccesses = 0;
-  if (outcome === "blocked") next.consecutiveBlocked += 1;
+  if (outcome === "blocked") {
+    next.consecutiveFailures = 0;
+    next.consecutiveBlocked += 1;
+    return next;
+  }
   if (outcome === "failed" || outcome === "quarantined") {
     next.consecutiveFailures += 1;
     next.consecutiveBlocked = 0;
+    return next;
   }
+
+  next.consecutiveFailures = 0;
+  next.consecutiveBlocked = 0;
   return next;
 }

--- a/Projects/continuous/Qor/victor/src/heartbeat/types.ts
+++ b/Projects/continuous/Qor/victor/src/heartbeat/types.ts
@@ -1,0 +1,39 @@
+export type HeartbeatBranch =
+  | "observed"
+  | "claimed"
+  | "executed"
+  | "blocked"
+  | "failed"
+  | "quarantined"
+  | "persisted";
+
+export type HeartbeatRecordStatus =
+  | "completed"
+  | "blocked"
+  | "failed"
+  | "quarantined"
+  | "no-op";
+
+export interface HeartbeatEvidenceRef {
+  kind:
+    | "service-check"
+    | "space-error-check"
+    | "project-scan"
+    | "task-writeback"
+    | "memory-write";
+  target: string;
+  status: "success" | "failure" | "missing";
+  artifact: string | null;
+}
+
+export interface HeartbeatRecord {
+  tickId: string;
+  sessionId: string;
+  startedAt: string;
+  finishedAt: string | null;
+  status: HeartbeatRecordStatus;
+  branchHistory: HeartbeatBranch[];
+  claimedTaskId: string | null;
+  summary: string;
+  evidence: HeartbeatEvidenceRef[];
+}

--- a/Projects/continuous/Qor/victor/tests/heartbeat.test.ts
+++ b/Projects/continuous/Qor/victor/tests/heartbeat.test.ts
@@ -6,15 +6,19 @@ import {
   handleEmptyQueue,
   inferLifecycleStage,
   forgeTaskToTask,
+  heartbeat,
   AutonomyLevel,
   type AgentContext,
   type HeartbeatResult,
   type PhaseContext,
 } from "../src/heartbeat/mod";
+import type { RuntimeAgentContext } from "../src/heartbeat/runtime";
 
 const FORGE_TMP = "/tmp/forge-heartbeat-test";
 const FORGE_PHASES = `${FORGE_TMP}/phases.json`;
 const MISSING_FORGE_PHASES = `${FORGE_TMP}/missing-phases.json`;
+const HEARTBEAT_STATE_PATH = `${FORGE_TMP}/heartbeat-state.json`;
+const HEARTBEAT_RECORDS_DIR = `${FORGE_TMP}/heartbeat-records`;
 
 function writeForgePhases(phases: unknown[]) {
   mkdirSync(FORGE_TMP, { recursive: true });
@@ -30,6 +34,15 @@ function makeCtx(overrides: Partial<AgentContext> = {}): AgentContext {
     progress: { completed: 0, total: 10 },
     blockers: [],
     forgeQueuePath: MISSING_FORGE_PHASES,
+    ...overrides,
+  };
+}
+
+function makeRuntimeCtx(
+  overrides: Partial<RuntimeAgentContext> = {},
+): RuntimeAgentContext {
+  return {
+    ...makeCtx(),
     ...overrides,
   };
 }
@@ -261,6 +274,34 @@ describe("Forge-first task derivation", () => {
     }));
     expect(result.status).toBe("AUTO_DERIVED");
     expect(result.tasks![0].source).toStartWith("forge:queue:");
+  });
+});
+
+describe("runtime heartbeat record sealing", () => {
+  beforeEach(() => mkdirSync(FORGE_TMP, { recursive: true }));
+  afterEach(() => rmSync(FORGE_TMP, { recursive: true, force: true }));
+
+  it("returns no-op with a persisted record when observation succeeds without claim", async () => {
+    const result = await heartbeat(makeRuntimeCtx({
+      phase: makePhase({ hasPlan: false }),
+      heartbeatStatePath: HEARTBEAT_STATE_PATH,
+      heartbeatRecordsDir: HEARTBEAT_RECORDS_DIR,
+    }));
+
+    expect(result.status).toBe("AUTO_DERIVED");
+    expect(result.heartbeatStatus).toBe("no-op");
+    expect(result.heartbeatRecordPath).toContain("/heartbeat-records/");
+  });
+
+  it("does not report completed for empty-queue observation ticks", async () => {
+    const result = await heartbeat(makeRuntimeCtx({
+      phase: makePhase({ hasPlan: false }),
+      heartbeatStatePath: HEARTBEAT_STATE_PATH,
+      heartbeatRecordsDir: HEARTBEAT_RECORDS_DIR,
+    }));
+
+    expect(result.executionStatus).toBe("no-op");
+    expect(result.executionStatus).not.toBe("completed");
   });
 });
 

--- a/Projects/continuous/Qor/victor/tests/state-persistence.test.ts
+++ b/Projects/continuous/Qor/victor/tests/state-persistence.test.ts
@@ -3,11 +3,15 @@ import { mkdirSync, rmSync } from "fs";
 import {
   applyHeartbeatOutcome,
   loadHeartbeatState,
+  loadHeartbeatRecord,
+  saveHeartbeatRecord,
   saveHeartbeatState,
 } from "../src/heartbeat/state-persistence";
+import type { HeartbeatRecord } from "../src/heartbeat/types";
 
 const TMP_DIR = "/tmp/victor-heartbeat-state-test";
 const STATE_PATH = `${TMP_DIR}/state.json`;
+const RECORD_PATH = `${TMP_DIR}/heartbeat-records/tick-1.json`;
 
 beforeEach(() => mkdirSync(TMP_DIR, { recursive: true }));
 afterEach(() => rmSync(TMP_DIR, { recursive: true, force: true }));
@@ -51,5 +55,30 @@ describe("state persistence", () => {
   it("increments failure streak on failed", () => {
     const next = applyHeartbeatOutcome(loadHeartbeatState(STATE_PATH), "failed", "2026-04-07T00:00:00Z", "t1");
     expect(next.consecutiveFailures).toBe(1);
+  });
+
+  it("treats no-op as non-successful but non-failing", () => {
+    const prior = applyHeartbeatOutcome(loadHeartbeatState(STATE_PATH), "failed", "2026-04-07T00:00:00Z", "t1");
+    const next = applyHeartbeatOutcome(prior, "no-op", "2026-04-07T00:01:00Z");
+    expect(next.consecutiveSuccesses).toBe(0);
+    expect(next.consecutiveFailures).toBe(0);
+    expect(next.consecutiveBlocked).toBe(0);
+    expect(next.lastTickStatus).toBe("no-op");
+  });
+
+  it("persists and reloads heartbeat records", () => {
+    const record: HeartbeatRecord = {
+      tickId: "tick-1",
+      sessionId: "tick-1",
+      startedAt: "2026-04-07T00:00:00Z",
+      finishedAt: "2026-04-07T00:00:01Z",
+      status: "no-op",
+      branchHistory: ["observed", "persisted"],
+      claimedTaskId: null,
+      summary: "Observation completed without execution.",
+      evidence: [{ kind: "project-scan", target: "forge-queue", status: "success", artifact: null }],
+    };
+    saveHeartbeatRecord(RECORD_PATH, record);
+    expect(loadHeartbeatRecord(RECORD_PATH)).toEqual(record);
   });
 });


### PR DESCRIPTION
## Summary
- add sealed heartbeat tick records and return the persisted record path
- classify observation-only empty-queue ticks as `no-op` instead of implied success
- extend heartbeat runtime and persistence coverage for fail-closed observation semantics

## Verification
- `bun test /tmp/qor-release-wt/Projects/continuous/Qor/victor/tests/heartbeat.test.ts /tmp/qor-release-wt/Projects/continuous/Qor/victor/tests/state-persistence.test.ts`
